### PR TITLE
#comment changed to have diesel use r2d2 from it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,7 @@ authors = ["Darayus Nanavati <darayus.contact@gmail.com>"]
 [dependencies]
 
 iron = "0.6"
-diesel = ">=1.0"
-r2d2 = ">=0.7, <0.9"
-r2d2-diesel = "1.0"
+diesel = { version = "^1.0.0", features = ["r2d2"] }
 
 [[example]]
 


### PR DESCRIPTION

Removed the `r2d2-diesel` crate and just use the `r2d2` in diesel.